### PR TITLE
Improve portfolio and embed resume

### DIFF
--- a/my-portfolio/app/about/page.tsx
+++ b/my-portfolio/app/about/page.tsx
@@ -1,12 +1,10 @@
-// app/about/page.tsx
 export default function About() {
-    return (
-      <div className="min-h-screen flex flex-col items-center justify-center">
-        <h1 className="text-4xl font-bold">About Me</h1>
-        <p className="mt-4 max-w-2xl text-center">
-          This page will detail your background, experience, and passions.
-        </p>
-      </div>
-    );
-  }
-  
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-8">
+      <h1 className="text-4xl font-bold mb-4">About Me</h1>
+      <p className="max-w-3xl text-center">
+        {`I'm Soham Sachin Sarpotdar, a software engineer with experience at Illumio and VMware. I specialize in full stack development, cloud technologies and creating resilient systems. I'm starting as a Software Engineer at Meta soon!`}
+      </p>
+    </div>
+  );
+}

--- a/my-portfolio/app/contact/page.tsx
+++ b/my-portfolio/app/contact/page.tsx
@@ -1,12 +1,9 @@
-// app/contact/page.tsx
 export default function Contact() {
-    return (
-      <div className="min-h-screen flex flex-col items-center justify-center">
-        <h1 className="text-4xl font-bold">Contact Me</h1>
-        <p className="mt-4 max-w-2xl text-center">
-          Get in touch through this page. You might integrate a form or display your social links.
-        </p>
-      </div>
-    );
-  }
-  
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-8">
+      <h1 className="text-4xl font-bold mb-4">Contact Me</h1>
+      <p className="mb-2">Email: <a className="underline" href="mailto:sohamsachin.sarpotdar@gmail.com">sohamsachin.sarpotdar@gmail.com</a></p>
+      <p>LinkedIn: <a className="underline" href="https://www.linkedin.com/in/sohamsachin-sarpotdar/" target="_blank" rel="noopener noreferrer">View my profile</a></p>
+    </div>
+  );
+}

--- a/my-portfolio/app/layout.tsx
+++ b/my-portfolio/app/layout.tsx
@@ -1,10 +1,9 @@
-// app/layout.tsx
 import './globals.css';
 import Link from 'next/link';
 
 export const metadata = {
-  title: 'My Portfolio',
-  description: 'A dark-themed portfolio site',
+  title: 'Soham Sarpotdar Portfolio',
+  description: 'Enterprise grade UI portfolio site',
 };
 
 export default function RootLayout({
@@ -14,28 +13,18 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className="bg-black text-white">
-        <header className="p-4 flex justify-between items-center">
-          <h1 className="text-xl font-bold">My Portfolio</h1>
-          <nav>
-            <Link href="/" className="mx-2">
-              Home
-            </Link>
-            <Link href="/about" className="mx-2">
-              About
-            </Link>
-            <Link href="/projects" className="mx-2">
-              Projects
-            </Link>
-            <Link href="/contact" className="mx-2">
-              Contact
-            </Link>
+      <body className="bg-black text-white min-h-screen flex flex-col">
+        <header className="p-6 bg-gray-900 flex justify-between items-center shadow-md">
+          <h1 className="text-2xl font-bold">Soham Sarpotdar</h1>
+          <nav className="space-x-4">
+            <Link href="/" className="hover:underline">Home</Link>
+            <Link href="/about" className="hover:underline">About</Link>
+            <Link href="/projects" className="hover:underline">Projects</Link>
+            <Link href="/contact" className="hover:underline">Contact</Link>
           </nav>
         </header>
-        <main>{children}</main>
-        <footer className="p-4 text-center">
-          © {new Date().getFullYear()} My Portfolio. All rights reserved.
-        </footer>
+        <main className="flex-grow">{children}</main>
+        <footer className="p-4 text-center bg-gray-900">© {new Date().getFullYear()} Soham Sarpotdar</footer>
       </body>
     </html>
   );

--- a/my-portfolio/app/page.tsx
+++ b/my-portfolio/app/page.tsx
@@ -1,11 +1,15 @@
-// app/page.tsx
+import Hero from '../components/Hero';
+import Experience from '../components/Experience';
+import ProjectsSection from '../components/ProjectsSection';
+import Skills from '../components/Skills';
+
 export default function Home() {
   return (
-    <main className="flex flex-col items-center justify-center min-h-screen">
-      <h1 className="text-4xl font-bold">Welcome to My Portfolio</h1>
-      <p className="mt-4">
-        This is the basic setup. More features and animations coming soon.
-      </p>
+    <main>
+      <Hero />
+      <Experience />
+      <ProjectsSection />
+      <Skills />
     </main>
   );
 }

--- a/my-portfolio/app/projects/page.tsx
+++ b/my-portfolio/app/projects/page.tsx
@@ -1,12 +1,9 @@
-// app/projects/page.tsx
+import ProjectsSection from '../../components/ProjectsSection';
+
 export default function Projects() {
-    return (
-      <div className="min-h-screen flex flex-col items-center justify-center">
-        <h1 className="text-4xl font-bold">My Projects</h1>
-        <p className="mt-4 max-w-2xl text-center">
-          Here you can showcase your portfolio projects, descriptions, and links.
-        </p>
-      </div>
-    );
-  }
-  
+  return (
+    <main>
+      <ProjectsSection />
+    </main>
+  );
+}

--- a/my-portfolio/components/Experience.tsx
+++ b/my-portfolio/components/Experience.tsx
@@ -1,0 +1,27 @@
+export default function Experience() {
+  return (
+    <section className="py-12 max-w-4xl mx-auto">
+      <h2 className="text-3xl font-bold mb-6 text-center">Experience</h2>
+      <div className="space-y-6">
+        <div>
+          <h3 className="text-xl font-semibold">Illumio - Software Engineering Intern</h3>
+          <p className="text-sm italic">May 2024 - Aug 2024</p>
+          <ul className="list-disc list-inside ml-5">
+            <li>Developed Core Insights - Risky Ports feature using React, Node.js and Ruby on Rails.</li>
+            <li>Architected data pipeline storing 10+ insights in PostgreSQL.</li>
+            <li>Improved backend API performance by 35%.</li>
+          </ul>
+        </div>
+        <div>
+          <h3 className="text-xl font-semibold">VMware - Software Engineer</h3>
+          <p className="text-sm italic">Jan 2022 - Aug 2023</p>
+          <ul className="list-disc list-inside ml-5">
+            <li>Architected Velocloud Orchestrator with TypeScript and Angular.</li>
+            <li>Implemented Redis caching and Kubernetes deployment.</li>
+            <li>Revamped dashboard UI with Vue.js increasing user satisfaction by 19%.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/my-portfolio/components/Hero.tsx
+++ b/my-portfolio/components/Hero.tsx
@@ -1,0 +1,8 @@
+export default function Hero() {
+  return (
+    <section className="flex flex-col items-center justify-center py-20 bg-gradient-to-r from-purple-600 via-pink-500 to-red-500 text-white text-center">
+      <h1 className="text-5xl font-extrabold mb-4">Soham Sachin Sarpotdar</h1>
+      <p className="text-xl max-w-2xl">Software Engineer joining Meta in 5 days. Passionate about building secure, scalable applications.</p>
+    </section>
+  );
+}

--- a/my-portfolio/components/ProjectsSection.tsx
+++ b/my-portfolio/components/ProjectsSection.tsx
@@ -1,0 +1,13 @@
+export default function ProjectsSection() {
+  return (
+    <section className="py-12 bg-gray-900 text-white">
+      <div className="max-w-4xl mx-auto">
+        <h2 className="text-3xl font-bold mb-6 text-center">Highlighted Project</h2>
+        <div className="bg-gray-800 p-6 rounded-lg shadow-md">
+          <h3 className="text-2xl font-semibold">TechFusion: Unified Social & E-commerce Platform</h3>
+          <p className="mt-2">Built with React, Redux, Firebase, Socket.io and GraphQL. Supports over 1000 users with real-time updates and 99.8% uptime using Kubernetes.</p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/my-portfolio/components/Skills.tsx
+++ b/my-portfolio/components/Skills.tsx
@@ -1,0 +1,8 @@
+export default function Skills() {
+  return (
+    <section className="py-12 max-w-4xl mx-auto">
+      <h2 className="text-3xl font-bold mb-6 text-center">Technical Skills</h2>
+      <p className="text-center">Python, JavaScript, TypeScript, C++, Go, Rust, SQL, React, Node.js, Kubernetes, PostgreSQL and more.</p>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a hero section, resume experience, project highlight and skills components
- revamp layout with a darker enterprise look
- fill about and contact pages with real content
- hook components into the homepage

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683f902777b08332b75196e9b2fea262